### PR TITLE
Add unit test for Recommended component

### DIFF
--- a/Frontend/src/pages/home/_tests_/Recommended.test.jsx
+++ b/Frontend/src/pages/home/_tests_/Recommended.test.jsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Recommended from '../Recommended';
+import { useFetchAllBooksQuery } from '../../../redux/features/cart/books/booksApi';
+
+vi.mock('../../../redux/features/cart/books/booksApi', () => ({
+  useFetchAllBooksQuery: vi.fn(),
+}));
+
+vi.mock('../books/bookcard', () => ({
+  default: ({ book }) => <div>{book.title}</div>,
+}));
+
+vi.mock('swiper/react', () => ({
+  Swiper: ({ children }) => <div data-testid="swiper">{children}</div>,
+  SwiperSlide: ({ children }) => <div data-testid="swiperslide">{children}</div>,
+}));
+
+vi.mock('swiper/modules', () => ({
+  Pagination: {},
+  Navigation: {},
+}));
+
+
+describe('Recommended Component', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders book cards from index 8 onwards', () => {
+    const sampleBooks = Array.from({ length: 10 }, (_, i) => ({
+      _id: String(i),
+      title: `Book ${i}`,
+    }));
+
+    useFetchAllBooksQuery.mockReturnValue({ data: { books: sampleBooks } });
+
+    render(
+      <MemoryRouter>
+        <Recommended />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/recommended for you/i)).toBeInTheDocument();
+
+    const expected = sampleBooks.slice(8, 16);
+    expect(screen.getAllByTestId('swiperslide')).toHaveLength(expected.length);
+    expected.forEach((book) => {
+      expect(screen.getByText(book.title)).toBeInTheDocument();
+    });
+  });
+
+  it('renders no slides when there are no books', () => {
+    useFetchAllBooksQuery.mockReturnValue({ data: { books: [] } });
+
+    render(
+      <MemoryRouter>
+        <Recommended />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryAllByTestId('swiperslide')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for `Recommended` component to check rendered slides

## Testing
- `npm test --prefix Frontend -- -t Recommended.test.jsx` *(fails: Failed to resolve import "../Navbar" from Navbar.test.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68496b47039083278758dea9cbf4b5a7